### PR TITLE
Refactor Google Cloud auth to support service accounts.

### DIFF
--- a/proj/speech_to_text/google_cloud_auth.py
+++ b/proj/speech_to_text/google_cloud_auth.py
@@ -1,0 +1,29 @@
+from google.auth.transport.requests import Request
+from google.auth import default
+from google.auth.exceptions import DefaultCredentialsError
+
+def gcloud_auth():
+  credentials = None
+
+  try:
+    credentials, _ = default(
+        scopes=['https://www.googleapis.com/auth/drive'],
+    )
+  except DefaultCredentialsError:
+    print('No credentials found. Run gcloud auth application-default login'
+          ' --impersonate-service-account SERVICE_ACCOUNT_EMAIL to configure '
+          'the service account, or set the GOOGLE_APPLICATION_CREDENTIALS '
+          'environment variable to a service account key file.')
+
+  if credentials and not credentials.valid:
+    credentials.refresh(Request())
+
+  if credentials and credentials.valid:
+    print("Credentials valid.")
+    return credentials
+  else:
+    print("Credentials invalid.")
+    return None
+
+if __name__ == '__main__':
+    gcloud_auth()

--- a/proj/speech_to_text/google_cloud_sync.py
+++ b/proj/speech_to_text/google_cloud_sync.py
@@ -1,13 +1,9 @@
 import datetime
 import os
 
-from google.oauth2.credentials import Credentials
-from google.oauth2 import service_account
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
+from google_cloud_auth import gcloud_auth
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
-from google_cloud_auth import gcloud_auth
 
 # If modifying these SCOPES, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/drive']

--- a/proj/speech_to_text/google_cloud_sync.py
+++ b/proj/speech_to_text/google_cloud_sync.py
@@ -2,34 +2,22 @@ import datetime
 import os
 
 from google.oauth2.credentials import Credentials
+from google.oauth2 import service_account
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
+from google_cloud_auth import gcloud_auth
 
 # If modifying these SCOPES, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/drive']
 
-
 def main():
-    creds = None
-    # The file token.json stores the user's access and refresh tokens, and is
-    # created automatically when the authorization flow completes for the first time.
-    try:
-        creds = Credentials.from_authorized_user_file('token.json', SCOPES)
-    except FileNotFoundError:
-        pass
+    creds = gcloud_auth()
 
-    # If there are no (valid) credentials available, prompt the user to log in.
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file('credentials.json', SCOPES)
-            creds = flow.run_local_server(port=0)
-        # Save the credentials for the next run
-        with open('token.json', 'w') as token:
-            token.write(creds.to_json())
+    if creds is None or not creds.valid:
+        print('Service account credentials not found. Exiting.')
+        exit(1)
 
     # Build the Google Drive API client
     service = build('drive', 'v3', credentials=creds)


### PR DESCRIPTION
Post-merge, there are two ways to run this:
- service account impersonation, which can be automatically attached on google infra. not sure if I can set this up for out-of-domain users.
- set an env variable to point to a creds file which I will share via slack